### PR TITLE
Support 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,16 +2,11 @@
 build-backend = "setuptools.build_meta"
 requires = [
   # XXX must pin to exactly this to be able to do pip install -e .
-  "setuptools==63.0.0b1",
+  "setuptools==65.5.1",
 ]
-
-[tool.setuptools.package-data]
-pytest_bdd_html = ["*.csv"]
 
 [project]
-authors = [
-  {name = "slavos1", email = "slavos1@example.com"},
-]
+authors = [{ name = "slavos1", email = "slavos1@example.com" }]
 version = "0.1.13a0"
 # https://pythonhosted.org/an_example_pypi_project/setuptools.html#classifiers
 classifiers = [
@@ -37,17 +32,21 @@ dependencies = [
 ]
 description = "pytest plugin to display BDD info in HTML test report"
 keywords = ["pytest", "html", "bdd", "report"]
-license = {text = "MIT"}
+license = { text = "MIT" }
 name = "pytest-bdd-html"
 readme = "README.rst"
 requires-python = ">=3.7"
-urls = {Homepage = "https://github.com/slavos1/pytest-bdd-html", Documentation = "https://github.com/slavos1/pytest-bdd-html/blob/main/README.rst"}
+urls = { Homepage = "https://github.com/slavos1/pytest-bdd-html", Documentation = "https://github.com/slavos1/pytest-bdd-html/blob/main/README.rst" }
 
 [project.entry-points."pytest11"]
 bdd-html = "pytest_bdd_html.plugin"
 
 [tool.setuptools]
+include-package-data = true
 packages = ["pytest_bdd_html"]
+
+[tool.setuptools.package-data]
+pytest_bdd_html = ["**/*.css"]
 
 [tool.bumpver]
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ requires = [
   "setuptools==63.0.0b1",
 ]
 
+[tool.setuptools.package-data]
+pytest_bdd_html = ["*.csv"]
+
 [project]
 authors = [
   {name = "slavos1", email = "slavos1@example.com"},

--- a/pytest_bdd_html/plugin.py
+++ b/pytest_bdd_html/plugin.py
@@ -76,7 +76,8 @@ def pytest_runtest_makereport(item, call):  # pylint:disable=unused-argument
     outcome = yield
     report = outcome.get_result()
     meta = dict(item.user_properties)
-    if func_doc := item.function.__doc__:
+    fonc_doc = item.function.__doc__
+    if func_doc:
         func_doc = func_doc.splitlines()[0]
     report.description = dict(doc=func_doc or NO_DESCRIPTION)
     if "feature" in meta:

--- a/pytest_bdd_html/plugin.py
+++ b/pytest_bdd_html/plugin.py
@@ -76,7 +76,7 @@ def pytest_runtest_makereport(item, call):  # pylint:disable=unused-argument
     outcome = yield
     report = outcome.get_result()
     meta = dict(item.user_properties)
-    fonc_doc = item.function.__doc__
+    func_doc = item.function.__doc__
     if func_doc:
         func_doc = func_doc.splitlines()[0]
     report.description = dict(doc=func_doc or NO_DESCRIPTION)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup()
+

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-
-import setuptools
-
-if __name__ == "__main__":
-    setuptools.setup(package_data={'': ['**/*.csv']},
-    include_package_data=True)
-

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,6 @@
 import setuptools
 
 if __name__ == "__main__":
-    setuptools.setup()
+    setuptools.setup(package_data={'': ['**/*.csv']},
+    include_package_data=True)
 


### PR DESCRIPTION
- Regress walrus syntax to 3.7-compatible syntax
- Upgrade setuptools reference
- Autoformat toml file (IDE did this for me)
- Add setuptools.package-data.. I think if you just `pip install .` with only a `pyproject.toml`, it doesn't seem to include the css deps without that extra package-data parameter.